### PR TITLE
Use size-bounded DoubleCircularBuffer instead of unbounded Queue

### DIFF
--- a/src/main/java/frc/robot/subsystems/drive/SwerveModuleIOTalonFX.java
+++ b/src/main/java/frc/robot/subsystems/drive/SwerveModuleIOTalonFX.java
@@ -17,11 +17,10 @@ import com.ctre.phoenix6.signals.AbsoluteSensorRangeValue;
 import com.ctre.phoenix6.signals.FeedbackSensorSourceValue;
 import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
+import edu.wpi.first.util.DoubleCircularBuffer;
 import edu.wpi.first.wpilibj.DriverStation;
 import frc.robot.constants.Constants.Swerve.Modules;
 import frc.robot.utils.ctre.Phoenix6Utils;
-
-import java.util.Queue;
 
 public class SwerveModuleIOTalonFX implements SwerveModuleIO {
     private final TalonFX driveMotor;
@@ -51,10 +50,10 @@ public class SwerveModuleIOTalonFX implements SwerveModuleIO {
     private final StatusSignal<Double> _turnStatorCurrent;
     private final StatusSignal<Double> _turnDeviceTemp;
 
-    // Odometry StatusSignal update queues
-    private final Queue<Double> timestampQueue;
-    private final Queue<Double> drivePositionSignalQueue;
-    private final Queue<Double> turnPositionSignalQueue;
+    // Odometry StatusSignal update buffers
+    private final DoubleCircularBuffer timestampBuffer;
+    private final DoubleCircularBuffer drivePositionSignalBuffer;
+    private final DoubleCircularBuffer turnPositionSignalBuffer;
 
     public SwerveModuleIOTalonFX(
             final TalonFX driveMotor,
@@ -89,9 +88,9 @@ public class SwerveModuleIOTalonFX implements SwerveModuleIO {
         this._turnStatorCurrent = turnMotor.getStatorCurrent();
         this._turnDeviceTemp = turnMotor.getDeviceTemp();
 
-        this.timestampQueue = odometryThreadRunner.makeTimestampQueue();
-        this.drivePositionSignalQueue = odometryThreadRunner.registerSignal(driveMotor, _drivePosition);
-        this.turnPositionSignalQueue = odometryThreadRunner.registerSignal(turnMotor, _turnPosition);
+        this.timestampBuffer = odometryThreadRunner.makeTimestampBuffer();
+        this.drivePositionSignalBuffer = odometryThreadRunner.registerSignal(driveMotor, _drivePosition);
+        this.turnPositionSignalBuffer = odometryThreadRunner.registerSignal(turnMotor, _turnPosition);
     }
 
     @SuppressWarnings("DuplicatedCode")
@@ -181,14 +180,14 @@ public class SwerveModuleIOTalonFX implements SwerveModuleIO {
         inputs.turnStatorCurrentAmps = _turnStatorCurrent.getValue();
         inputs.turnTempCelsius = _turnDeviceTemp.getValue();
 
-        inputs.odometryTimestampsSec = timestampQueue.stream().mapToDouble(time -> time).toArray();
-        timestampQueue.clear();
+        inputs.odometryTimestampsSec = OdometryThreadRunner.writeBufferToArray(timestampBuffer);
+        timestampBuffer.clear();
 
-        inputs.odometryDrivePositionsRots = drivePositionSignalQueue.stream().mapToDouble(pos -> pos).toArray();
-        drivePositionSignalQueue.clear();
+        inputs.odometryDrivePositionsRots = OdometryThreadRunner.writeBufferToArray(drivePositionSignalBuffer);
+        drivePositionSignalBuffer.clear();
 
-        inputs.odometryTurnPositionRots = turnPositionSignalQueue.stream().mapToDouble(pos -> pos).toArray();
-        turnPositionSignalQueue.clear();
+        inputs.odometryTurnPositionRots = OdometryThreadRunner.writeBufferToArray(turnPositionSignalBuffer);
+        turnPositionSignalBuffer.clear();
     }
 
     /**

--- a/src/main/java/frc/robot/subsystems/gyro/GyroIOPigeon2.java
+++ b/src/main/java/frc/robot/subsystems/gyro/GyroIOPigeon2.java
@@ -6,11 +6,10 @@ import com.ctre.phoenix6.configs.Pigeon2Configuration;
 import com.ctre.phoenix6.hardware.ParentDevice;
 import com.ctre.phoenix6.hardware.Pigeon2;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.util.DoubleCircularBuffer;
 import frc.robot.constants.HardwareConstants;
 import frc.robot.subsystems.drive.OdometryThreadRunner;
 import frc.robot.utils.ctre.Phoenix6Utils;
-
-import java.util.Queue;
 
 public class GyroIOPigeon2 implements GyroIO {
     private final Pigeon2 pigeon;
@@ -24,9 +23,9 @@ public class GyroIOPigeon2 implements GyroIO {
     private final StatusSignal<Double> _rollVelocity;
     private final StatusSignal<Boolean> _faultHardware;
 
-    // StatusSignal queues for high-freq odometry
-    private final Queue<Double> timestampQueue;
-    private final Queue<Double> yawSignalQueue;
+    // StatusSignal buffers for high-freq odometry
+    private final DoubleCircularBuffer timestampBuffer;
+    private final DoubleCircularBuffer yawSignalBuffer;
 
     public GyroIOPigeon2(
             final HardwareConstants.GyroConstants gyroConstants,
@@ -42,8 +41,8 @@ public class GyroIOPigeon2 implements GyroIO {
         this._rollVelocity = pigeon.getAngularVelocityXWorld();
         this._faultHardware = pigeon.getFault_Hardware();
 
-        this.timestampQueue = odometryThreadRunner.makeTimestampQueue();
-        this.yawSignalQueue = odometryThreadRunner.registerSignal(pigeon, _yaw);
+        this.timestampBuffer = odometryThreadRunner.makeTimestampBuffer();
+        this.yawSignalBuffer = odometryThreadRunner.registerSignal(pigeon, _yaw);
     }
 
     @SuppressWarnings("DuplicatedCode")
@@ -67,11 +66,11 @@ public class GyroIOPigeon2 implements GyroIO {
         inputs.rollVelocityDegPerSec = _rollVelocity.getValue();
         inputs.hasHardwareFault = _faultHardware.getValue();
 
-        inputs.odometryTimestampsSec = timestampQueue.stream().mapToDouble(time -> time).toArray();
-        timestampQueue.clear();
+        inputs.odometryTimestampsSec = OdometryThreadRunner.writeBufferToArray(timestampBuffer);
+        timestampBuffer.clear();
 
-        inputs.odometryYawPositionsDeg = yawSignalQueue.stream().mapToDouble(yaw -> yaw).toArray();
-        yawSignalQueue.clear();
+        inputs.odometryYawPositionsDeg = OdometryThreadRunner.writeBufferToArray(yawSignalBuffer);
+        yawSignalBuffer.clear();
     }
 
     // TODO: duplicated code warnings here aren't exactly amazing, but I can't really think of a way to extract


### PR DESCRIPTION
WPILib's `DoubleCircularBuffer` has an upper bound on the maximum size (amount of elements) that can be in the buffer - this is desirable so that the size of the queue/buffer does not continuously grow unbounded during a particularly long loop cycle or IO read.

This replaces the old implementation that used `Queue`, and is better than using `ArrayBlockingQueue`  because the oldest data is discarded when the size grows to its maximum instead of discarding the latest (newest) data.

Resolves #30.