### PR TITLE
Renamed CTREPhoenix6TalonFXSim.java to TalonFXSim

### DIFF
--- a/src/main/java/frc/robot/subsystems/drive/SwerveModuleIOTalonFXSim.java
+++ b/src/main/java/frc/robot/subsystems/drive/SwerveModuleIOTalonFXSim.java
@@ -26,15 +26,15 @@ import frc.robot.utils.control.DeltaTime;
 import frc.robot.utils.ctre.Phoenix6Utils;
 import frc.robot.utils.sim.SimUtils;
 import frc.robot.utils.sim.feedback.SimPhoenix6CANCoder;
-import frc.robot.utils.sim.motors.CTREPhoenix6TalonFXSim;
+import frc.robot.utils.sim.motors.TalonFXSim;
 
 public class SwerveModuleIOTalonFXSim implements SwerveModuleIO {
     private static final double SIM_UPDATE_PERIOD_SEC = 0.005;
 
     private final TalonFX driveMotor;
     private final TalonFX turnMotor;
-    private final CTREPhoenix6TalonFXSim driveSim;
-    private final CTREPhoenix6TalonFXSim turnSim;
+    private final TalonFXSim driveSim;
+    private final TalonFXSim turnSim;
     private final CANcoder turnEncoder;
     private final double magnetOffset;
 
@@ -81,7 +81,7 @@ public class SwerveModuleIOTalonFXSim implements SwerveModuleIO {
                 Modules.DRIVE_WHEEL_MOMENT_OF_INERTIA_KG_M_SQUARED
         );
 
-        this.driveSim = new CTREPhoenix6TalonFXSim(
+        this.driveSim = new TalonFXSim(
                 driveMotor,
                 Modules.DRIVER_GEAR_RATIO,
                 driveDCMotorSim::update,
@@ -100,7 +100,7 @@ public class SwerveModuleIOTalonFXSim implements SwerveModuleIO {
 
         this.turnEncoder = turnEncoder;
         this.magnetOffset = magnetOffset;
-        this.turnSim = new CTREPhoenix6TalonFXSim(
+        this.turnSim = new TalonFXSim(
                 turnMotor,
                 Modules.TURNER_GEAR_RATIO,
                 turnDCMotorSim::update,

--- a/src/main/java/frc/robot/utils/sim/motors/TalonFXSim.java
+++ b/src/main/java/frc/robot/utils/sim/motors/TalonFXSim.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-public class CTREPhoenix6TalonFXSim implements SimMotorController {
+public class TalonFXSim implements SimMotorController {
     private final List<TalonFXSimState> simStates;
     private final Consumer<Double> update;
     private final Consumer<Double> inputVoltage;
@@ -25,7 +25,7 @@ public class CTREPhoenix6TalonFXSim implements SimMotorController {
     private boolean hasRemoteSensor = false;
     private SimFeedbackSensor feedbackSensor;
 
-    private CTREPhoenix6TalonFXSim(
+    private TalonFXSim(
             final List<TalonFX> talonFXControllers,
             final List<TalonFXSimState> simStates,
             final double gearRatio,
@@ -49,7 +49,7 @@ public class CTREPhoenix6TalonFXSim implements SimMotorController {
         this.useSimStateTorqueCurrent = simStates.get(0);
     }
 
-    public CTREPhoenix6TalonFXSim(
+    public TalonFXSim(
             final List<TalonFX> talonFXControllers,
             final double gearRatio,
             final Consumer<Double> update,
@@ -68,7 +68,7 @@ public class CTREPhoenix6TalonFXSim implements SimMotorController {
         );
     }
 
-    public CTREPhoenix6TalonFXSim(
+    public TalonFXSim(
             final TalonFX talonFX,
             final double gearRatio,
             final Consumer<Double> update,


### PR DESCRIPTION
We no longer have a mix of Phoenix5 and Phoenix6 anymore, which makes the super long name of that class that was a holdover from 2023 useless.